### PR TITLE
1 4 modulo de vue 3 entendendo componentes

### DIFF
--- a/Vue/cookin-up/src/components/CardCategoria.vue
+++ b/Vue/cookin-up/src/components/CardCategoria.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type ICategoria from '@/insterfaces/ICategoria';
 import type { PropType } from 'vue';
-import Tag from './Tag.vue';
+import IngredienteSelecionavel from './IngredienteSelecionavel.vue';
 
 export default{
   /* Utilizamos a opção props de um componente para receber informações do componente pai */
@@ -10,7 +10,7 @@ export default{
       /* É possível deixar seu tipo mais rígido com o tipo utilitário PropType */
         categoria: {type: Object as PropType<ICategoria>, required:true}
     },
-    components: { Tag }
+    components: { IngredienteSelecionavel }
 }
 </script>
 
@@ -27,7 +27,7 @@ export default{
 
     <ul class="categoria__ingredientes">
         <li v-for="ingrediente in categoria.ingredientes" :key="ingrediente">
-            <Tag :texto="ingrediente"/>
+        <IngredienteSelecionavel :ingrediente="ingrediente"/>
         </li>
     </ul>
  </article>

--- a/Vue/cookin-up/src/components/CardCategoria.vue
+++ b/Vue/cookin-up/src/components/CardCategoria.vue
@@ -10,7 +10,8 @@ export default{
       /* É possível deixar seu tipo mais rígido com o tipo utilitário PropType */
         categoria: {type: Object as PropType<ICategoria>, required:true}
     },
-    components: { IngredienteSelecionavel }
+    components: { IngredienteSelecionavel },
+    emits:['adicionarIngrediente', 'removerIngrediente']
 }
 </script>
 
@@ -27,7 +28,13 @@ export default{
 
     <ul class="categoria__ingredientes">
         <li v-for="ingrediente in categoria.ingredientes" :key="ingrediente">
-        <IngredienteSelecionavel :ingrediente="ingrediente"/>
+          <!--  possível escutar o evento diretamente no componente pai, escrevendo v-on:nome-do-evento (ou @nome-do-evento) no consumo do componente filho; -->
+        <IngredienteSelecionavel 
+          :ingrediente="ingrediente"
+          @adicionarIngrediente="$emit('adicionarIngrediente', $event)"
+          @remover-ingrediente="$emit('removerIngrediente', $event)"
+          />
+          
         </li>
     </ul>
  </article>

--- a/Vue/cookin-up/src/components/ConteudoPrincipal.vue
+++ b/Vue/cookin-up/src/components/ConteudoPrincipal.vue
@@ -1,25 +1,51 @@
-<script lang="ts">
+<script setup lang="ts">
+import { ref } from 'vue';
 import SelecionarIngredientes from './SelecionarIngredientes.vue';
 import SuaLista from './SuaLista.vue';
 
-/* só importa dentro do export default com o component: { } */
+const ingredientes = ref<string[]>([]);
+
+function adicionarIngrediente(ingrediente: string) {
+  ingredientes.value.push(ingrediente)
+}
+function removerIngrediente(ingrediente: string) {
+  ingredientes.value = ingredientes.value.filter(iLista => ingrediente !== iLista);
+}
+</script>
+
+<!-- <script lang="ts">
+import SelecionarIngredientes from './SelecionarIngredientes.vue';
+import SuaLista from './SuaLista.vue';
+
+
 export default {
     data() {
         return{
-            ingredientes: ['Alho', 'Manteiga' , 'Orégano']
-        }
+            ingredientes: [] as string [] ,
+        };
     },
-/* para pode importar o selecionar ingredientes  */
-    components: { SelecionarIngredientes, SuaLista }
+
+    components: { SelecionarIngredientes, SuaLista },
+    methods: {
+      adicionarIngrediente(ingrediente: string){
+        this.ingredientes.push(ingrediente)
+      },
+      removerIngrediente(ingrediente: string) {
+            this.ingredientes = this.ingredientes.filter(ing => ing !==ingrediente);
+        }
+    }
 }
-</script>
+</script> -->
 
 <template>
     <main class="conteudo-principal">
 <!-- conteudo principal é pai de SuaLista (infredientes para passar o conteudo dos arrays) -->
        <SuaLista :ingredientes="ingredientes"/>
 <!-- conteudo principal é pai do selecionar ingredientes -->
-        <SelecionarIngredientes />
+        <SelecionarIngredientes 
+        @adicionar-ingrediente="adicionarIngrediente"
+        @remover-ingrediente="removerIngrediente"
+        />
     </main>
 </template>
 

--- a/Vue/cookin-up/src/components/IngredienteSelecionavel.vue
+++ b/Vue/cookin-up/src/components/IngredienteSelecionavel.vue
@@ -1,0 +1,32 @@
+<script lang="ts">
+import Tag from './Tag.vue';
+
+export default{
+    components:{ Tag },
+    props: {
+        ingrediente: { type: String, required: true}
+    },
+    data(){
+        return{
+            selecionado: false
+        }
+    }
+}
+</script>
+
+<template>
+    <button
+    class="ingrediente"
+    @:click="selecionado = !selecionado"
+    :aria-pressed="selecionado"
+    >
+        <Tag :texto="ingrediente" :ativa="selecionado"/>
+    </button>
+        
+</template>
+
+<style scoped>
+.ingrediente{
+    cursor: pointer;
+}
+</style>

--- a/Vue/cookin-up/src/components/IngredienteSelecionavel.vue
+++ b/Vue/cookin-up/src/components/IngredienteSelecionavel.vue
@@ -10,14 +10,31 @@ export default{
         return{
             selecionado: false
         }
-    }
+    },
+    methods: {
+        /* Criamos o componente IngredienteSelecionavel com o estado booleano selecionado. Com ele, conseguimos saber quando o ingrediente está selecionado ou não; */
+        aoCLicar(){
+            /* Cada ingrediente selecionável possui seu próprio estado: podemos mudar o valor do estado de um sem interferir no estado dos outros; */
+            this.selecionado = !this.selecionado
+            /* Podemos passar um estado como prop: o estado selecionado foi definido como o valor da prop ativa da Tag. Dessa forma, caso o estado mude, a prop ativa também muda e o visual da Tag irá mudar de acordo; */
+            if(this.selecionado){
+                /* Usamos $emit (no template) ou this.$emits (no script) para emitir um evento personalizado. O primeiro parâmetro é o nome do evento, e o segundo parâmetro (e consecutivos) é um dado JavaScript que o evento pode carregar; */
+                this.$emit('adicionarIngrediente', this.ingrediente)
+            } else {
+                this.$emit('removerIngrediente', this.ingrediente)
+            }
+        }
+    },
+    /* É uma boa prática definir os eventos na opção emits do componente; */
+    emits: ['adicionarIngrediente', 'removerIngrediente']
 }
 </script>
 
 <template>
+    <!-- Criamos o componente IngredienteSelecionavel com o estado booleano selecionado. Com ele, conseguimos saber quando o ingrediente está selecionado ou não; -->
     <button
     class="ingrediente"
-    @:click="selecionado = !selecionado"
+    @:click="aoCLicar"
     :aria-pressed="selecionado"
     >
         <Tag :texto="ingrediente" :ativa="selecionado"/>

--- a/Vue/cookin-up/src/components/SelecionarIngredientes.vue
+++ b/Vue/cookin-up/src/components/SelecionarIngredientes.vue
@@ -17,7 +17,8 @@ carrega o "caregorias:[]" depois o "created()" */
         async created() {
             this.categorias = await obterCategorias();
         },
-        components: { CardCategoria }
+        components: { CardCategoria },
+        emits: ['adicionarIngrediente', 'removerIngrediente']
     }
 </script>
 
@@ -33,7 +34,12 @@ carrega o "caregorias:[]" depois o "created()" */
         <ul class="categorias">
 <!-- v-for para mostrar todas as categorias -->
             <li v-for="categoria in categorias" :key="categoria.nome">
-            <CardCategoria :categoria="categoria"/>
+              <!--  possível escutar o evento diretamente no componente pai, escrevendo v-on:nome-do-evento (ou @nome-do-evento) no consumo do componente filho; -->
+            <CardCategoria 
+            :categoria="categoria"
+            @adicionar-ingrediente="$emit('adicionarIngrediente', $event)"
+            @remover-ingrediente="$emit('removerIngrediente', $event)"
+            />
             </li>
         </ul>
 


### PR DESCRIPTION
Controlar o visual de um componente usando estado e props:
Criamos o componente IngredienteSelecionavel com o estado booleano selecionado. Com ele, conseguimos saber quando o ingrediente está selecionado ou não;
Cada ingrediente selecionável possui seu próprio estado: podemos mudar o valor do estado de um sem interferir no estado dos outros;
Podemos passar um estado como prop: o estado selecionado foi definido como o valor da prop ativa da Tag. Dessa forma, caso o estado mude, a prop ativa também muda e o visual da Tag irá mudar de acordo;
Emitir e escutar eventos personalizados:
Usamos $emit (no template) ou this.$emits (no script) para emitir um evento personalizado. O primeiro parâmetro é o nome do evento, e o segundo parâmetro (e consecutivos) é um dado JavaScript que o evento pode carregar;
É uma boa prática definir os eventos na opção emits do componente;
É possível escutar o evento diretamente no componente pai, escrevendo v-on:nome-do-evento (ou @nome-do-evento) no consumo do componente filho;
É possível acessar o dado do evento por meio do $event ou, caso seja escrita uma função callback para o ouvinte do evento, podemos acessar o dado nos parâmetros dessa função. Nesse último caso, temos a vantagem de nomear e de tipar o dado do evento.